### PR TITLE
feat/PERM-2

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@greed/db": "workspace:*",
     "@greed/env": "workspace:*",
+    "@greed/permissions": "workspace:*",
     "@next-auth/prisma-adapter": "^1.0.5",
     "@tanstack/react-query": "^4.28.0",
     "@trpc/client": "^10.18.0",

--- a/apps/nextjs/src/server/api/routers/grid.ts
+++ b/apps/nextjs/src/server/api/routers/grid.ts
@@ -2,9 +2,10 @@ import { type Prisma } from "@greed/db";
 import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { creates, deletes, lists, updates } from "~/server/inputs/grid";
+import { GridPermission } from "@greed/permissions";
 
 export const gridRouter = createTRPCRouter({
-  gridList: protectedProcedure.query(async ({ ctx }) => {
+  list: protectedProcedure.query(async ({ ctx }) => {
     return await ctx.prisma.grid.findMany({
       where: {
         userId: ctx.session.user.id,
@@ -12,7 +13,7 @@ export const gridRouter = createTRPCRouter({
     });
   }),
 
-  gridByName: protectedProcedure.input(lists).query(async ({ ctx, input }) => {
+  byName: protectedProcedure.input(lists).query(async ({ ctx, input }) => {
     return await ctx.prisma.grid.findMany({
       where: {
         userId: ctx.session.user.id,
@@ -23,71 +24,118 @@ export const gridRouter = createTRPCRouter({
     });
   }),
 
-  gridCreate: protectedProcedure
-    .input(creates)
-    .mutation(async ({ ctx, input }) => {
-      try {
-        await ctx.prisma.grid.create({
-          data: {
-            ...input,
-            userId: ctx.session.user.id,
-          },
-        });
-      } catch (error) {
-        if ((<Prisma.PrismaClientKnownRequestError>error).code === "P2002") {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Please choose a different name for your grid.",
-            cause: error,
-          });
-        }
-        throw error;
-      }
-    }),
+  create: protectedProcedure.input(creates).mutation(async ({ ctx, input }) => {
+    try {
+      const grid = await ctx.prisma.grid.create({
+        data: {
+          ...input,
+          userId: ctx.session.user.id,
+        },
+      });
 
-  gridUpdate: protectedProcedure
-    .input(updates)
-    .mutation(async ({ ctx, input }) => {
-      try {
-        await ctx.prisma.grid.update({
-          where: {
-            id: input.id,
-          },
-          data: {
-            ...input,
-            userId: ctx.session.user.id,
-          },
+      // Give the creating user grid.owner permissions for the grid
+      await ctx.prisma.permission.create({
+        data: {
+          gridId: grid.id,
+          userId: ctx.session.user.id,
+          permissions: GridPermission.fromRole("grid.owner").serialized,
+        },
+      });
+    } catch (error) {
+      if ((<Prisma.PrismaClientKnownRequestError>error).code === "P2002") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Please choose a different name for your grid.",
+          cause: error,
         });
-      } catch (error) {
-        if ((<Prisma.PrismaClientKnownRequestError>error).code === "P2025") {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "The grid you're trying to update does not exist.",
-            cause: error,
-          });
-        }
-        throw error;
       }
-    }),
+      throw error;
+    }
+  }),
 
-  gridDelete: protectedProcedure
-    .input(deletes)
-    .mutation(async ({ ctx, input }) => {
-      try {
-        await ctx.prisma.grid.delete({
-          where: {
-            id: input.id,
-          },
+  update: protectedProcedure.input(updates).mutation(async ({ ctx, input }) => {
+    try {
+      const serializedPermissions = await ctx.prisma.permission.findFirst({
+        where: {
+          gridId: input.id,
+          userId: ctx.session.user.id,
+        },
+        select: {
+          permissions: true,
+        },
+      });
+
+      if (!serializedPermissions)
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Permissions not found.",
         });
-      } catch (error) {
-        if ((<Prisma.PrismaClientKnownRequestError>error).code === "P2025") {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "The grid you're trying to delete does not exist.",
-            cause: error,
-          });
-        }
-        throw error;
+      const perm = new GridPermission(serializedPermissions.permissions);
+      if (!perm.has("grid.update"))
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have the permissions to update this grid",
+        });
+
+      await ctx.prisma.grid.update({
+        where: {
+          id: input.id,
+        },
+        data: {
+          ...input,
+          userId: ctx.session.user.id,
+        },
+      });
+    } catch (error) {
+      if ((<Prisma.PrismaClientKnownRequestError>error).code === "P2025") {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "The grid you're trying to update does not exist.",
+          cause: error,
+        });
       }
-    }),
+      throw error;
+    }
+  }),
+
+  delete: protectedProcedure.input(deletes).mutation(async ({ ctx, input }) => {
+    try {
+      const serializedPermissions = await ctx.prisma.permission.findFirst({
+        where: {
+          gridId: input.id,
+          userId: ctx.session.user.id,
+        },
+        select: {
+          permissions: true,
+        },
+      });
+
+      if (!serializedPermissions)
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Permissions not found.",
+        });
+      const perm = new GridPermission(serializedPermissions.permissions);
+      if (!perm.has("grid.delete"))
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have the permissions to delete this grid",
+        });
+
+      await ctx.prisma.grid.delete({
+        where: {
+          id: input.id,
+        },
+      });
+    } catch (error) {
+      if ((<Prisma.PrismaClientKnownRequestError>error).code === "P2025") {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "The grid you're trying to delete does not exist.",
+          cause: error,
+        });
+      }
+      throw error;
+    }
+  }),
 });

--- a/packages/db/prisma/dbml/schema.dbml
+++ b/packages/db/prisma/dbml/schema.dbml
@@ -81,6 +81,10 @@ Table Permission {
   gridId String [not null]
   user User [not null]
   userId String [not null]
+
+  indexes {
+    (gridId, userId) [unique]
+  }
 }
 
 Table Content {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -100,6 +100,7 @@ model Permission {
     user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
     userId      String
 
+    @@unique([gridId, userId])
     @@index([gridId])
     @@index([userId])
 }

--- a/packages/permissions/Interfaces/IPermission.ts
+++ b/packages/permissions/Interfaces/IPermission.ts
@@ -2,7 +2,7 @@ import { type PermissionsOf } from "../types/PermissionsOf";
 import { type DefinitionOf } from "../types/DefinitionOf";
 import { z } from "zod";
 
-export default abstract class IPermission<
+export abstract class IPermission<
   Resources extends readonly string[],
   Operations extends readonly string[]
 > {

--- a/packages/permissions/classes/Permission.ts
+++ b/packages/permissions/classes/Permission.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import type IPermission from "../interfaces/IPermission";
+import { type IPermission } from "../interfaces/IPermission";
 import { type PermissionsOf } from "../types/PermissionsOf";
 import { type DefinitionOf } from "../types/DefinitionOf";
 

--- a/packages/permissions/interfaces/IPermission.ts
+++ b/packages/permissions/interfaces/IPermission.ts
@@ -1,0 +1,70 @@
+import { type PermissionsOf } from "../types/PermissionsOf";
+import { type DefinitionOf } from "../types/DefinitionOf";
+import { z } from "zod";
+
+export abstract class IPermission<
+  Resources extends readonly string[],
+  Operations extends readonly string[]
+> {
+  permissions: { serialized: string; value: number };
+  original: { serialized: string; value: number };
+  DEF: DefinitionOf<Resources, Operations>;
+  ROLE_DEF: Readonly<Record<string, PermissionsOf<Resources, Operations>[]>>;
+
+  constructor(
+    input: PermissionsOf<Resources, Operations>[] | number | string,
+    definition: DefinitionOf<Resources, Operations>,
+    roleDefinition: Readonly<
+      Record<string, PermissionsOf<Resources, Operations>[]>
+    >
+  ) {
+    this.DEF = definition;
+    this.ROLE_DEF = roleDefinition;
+    let calculatedPermissions = {
+      serialized: "0",
+      value: 0,
+    };
+    if (typeof input === "number") {
+      calculatedPermissions = {
+        serialized: input.toString(),
+        value: input,
+      };
+    }
+    if (typeof input === "string") {
+      calculatedPermissions = {
+        serialized: input,
+        value: z.coerce.number().parse(input),
+      };
+    } else if (Array.isArray(input)) {
+      const value = input.reduce((acc, curr) => acc | this.DEF[curr], 0);
+      calculatedPermissions = {
+        serialized: value.toString(),
+        value,
+      };
+    }
+    this.permissions = calculatedPermissions;
+    this.original = { ...this.permissions };
+  }
+
+  abstract get value(): number;
+  abstract get serialized(): string;
+  abstract has(
+    permission:
+      | PermissionsOf<Resources, Operations>
+      | PermissionsOf<Resources, Operations>[]
+  ): boolean;
+  abstract list(): PermissionsOf<Resources, Operations>[];
+  abstract add(
+    permission:
+      | PermissionsOf<Resources, Operations>
+      | PermissionsOf<Resources, Operations>[],
+    serialized?: boolean
+  ): string | number;
+  abstract remove(
+    permission:
+      | PermissionsOf<Resources, Operations>
+      | PermissionsOf<Resources, Operations>[],
+    serialized?: boolean
+  ): string | number | undefined;
+  abstract reset(): { serialized: string; value: number };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@greed/env':
         specifier: workspace:*
         version: link:../../packages/env
+      '@greed/permissions':
+        specifier: workspace:*
+        version: link:../../packages/permissions
       '@next-auth/prisma-adapter':
         specifier: ^1.0.5
         version: 1.0.5(@prisma/client@4.11.0)(next-auth@4.21.0)


### PR DESCRIPTION
[PERM-2](https://www.notion.so/Add-permissions-checks-to-grid-tRPC-procedures-a7157a99d01c4660806b3922c025b72a?pvs=4)
- Updates Prisma schema to have unique permission entry per user per grid
- Adds permission check to grid.update procedure
- Adds permission check to grid.delete procedure
- Adds creation of permission record on grid create with `grid.owner` permissions 